### PR TITLE
eval-config: add dummy for boot.kernelPackages.kernel.version

### DIFF
--- a/eval-config.nix
+++ b/eval-config.nix
@@ -29,6 +29,7 @@ let
     options = {
       boot.kernel.sysctl = dummy;
       boot.kernelModules = dummy;
+      boot.kernelPackages.kernel.version = optionValue "";
       boot.kernelParams = dummy;
       environment.systemPackages = dummy;
       networking.dhcpcd.denyInterfaces = dummy;


### PR DESCRIPTION
Using latest `master` with `nixpkgs-unstable` on non-NixOS results in the following error when executing `extra-container shell -E '{ containers.demo.config = {}; }'`:

```
Building containers...
error: attribute 'kernelPackages' missing

       at /nix/var/nix/profiles/per-user/root/channels/nixos/nixos/modules/virtualisation/nixos-containers.nix:275:19:

          274|   system = config.nixpkgs.localSystem.system;
          275|   kernelVersion = config.boot.kernelPackages.kernel.version;
             |                   ^
          276|
(use '--show-trace' to show detailed location information)
```

This PR adds a dummy default value for `config.boot.kernelPackages.kernel.version` similar to 90b619a89add38e1d61c06b728d3c669f6f586d6. With this modification the container is created successfully.