### PR TITLE
README: fix installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,9 @@ let
     pkgs.callPackage src { pkgSrc = src; };
 in
 {
-  systemPackages = [ extra-container ];
+  environment.systemPackages = [ extra-container ];
+  # if on NixOS > 20.09:
+  boot.extraSystemdUnitPaths = [ "/etc/systemd-mutable/system" ];
 }
 ```
 


### PR DESCRIPTION
There's no systemPackages, but environment.systemPackages.

Also, on > NixOS 20.09, `boot.extraSystemdUnitPaths` needs to be set, so
systemd keeps looking at `/etc/systemd-mutable/system`.