### PR TITLE
flake: add example of using specialArgs

### DIFF
--- a/examples/flake/flake.nix
+++ b/examples/flake/flake.nix
@@ -24,6 +24,11 @@
           containers.demo = {
             extra.addressPrefix = "10.250.0";
 
+            # In Nixpkgs > 22.11 (currently this means unstable), `specialArgs` is available as an option.
+            # It allows you to add module arguments that are evaluated outside the module system,
+            # meaning you are allowed to use them in e.g. `imports` without causing infinite recursion.
+            # specialArgs = { inherit inputs; };
+
             config = { pkgs, ... }: {
               systemd.services.hello = {
                 wantedBy = [ "multi-user.target" ];


### PR DESCRIPTION
My shared profiles and modules between containers and NixOS configurations expect the availability of certain extra module arguments, like `inputs`. To add these extra module arguments, I figured I had to add support for `specialArgs` to this project, but after looking into it, it turns out that this should be configured in `nixos-containers` instead. It just so happened that [recently support for `specialArgs` was added to `nixos-containers`](https://github.com/NixOS/nixpkgs/pull/216677). Considering this is probably a common need for those using `extra-container` in flakes, and to prevent them from having to go on a similar search as I had to today, I updated the flake example to include an example of using `specialArgs`.